### PR TITLE
Remove deprecated rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "prettier": "@devoxa/prettier-config",
   "dependencies": {
     "postcss-scss": "4.0.6",
-    "stylelint-config-prettier": "9.0.5",
     "stylelint-config-standard-scss": "10.0.0",
     "stylelint-order": "6.0.3",
     "stylelint-scss": "5.0.1"

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,7 @@
 const orderRules = require('./orderRules')
 
 module.exports = {
-  extends: ['stylelint-config-standard-scss', 'stylelint-config-prettier'],
+  extends: ['stylelint-config-standard-scss'],
   plugins: ['stylelint-order'],
   customSyntax: 'postcss-scss',
   ignoreFiles: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
@@ -25,9 +25,6 @@ module.exports = {
 
     // Disable this rule because we don't enforce any naming conventions for class selectors
     'selector-class-pattern': null,
-
-    // Change this rule to not clash with SCSS if/else statements
-    'block-closing-brace-newline-after': ['always', { ignoreAtRules: ['if', 'else'] }],
 
     // Disable this rule, because we want to layer our specificity for the internals of components
     'no-descending-specificity': null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,11 +1029,6 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-stylelint-config-prettier@9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz#9f78bbf31c7307ca2df2dd60f42c7014ee9da56e"
-  integrity sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
-
 stylelint-config-recommended-scss@^12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-12.0.0.tgz#9d9e82c46012649f11bfebcbc788f58e61860f33"


### PR DESCRIPTION
With Stylelint 15, all rules that enforce stylistic conventions have been deprecated. This means we no longer have to disable them ourselves to use `prettier` for formatting.
